### PR TITLE
Update Cloud Config

### DIFF
--- a/compute-variables.tf
+++ b/compute-variables.tf
@@ -23,6 +23,12 @@ variable "public_key_path" {
   default = "~/.ssh/id_gcp_ed25519.pub"
 }
 
+variable "public_key" {
+  type        = string
+  description = "SSH public key to use if public key file doesn't exist (if running in HCP Terraform)"
+  default     = ""
+}
+
 variable "user" {
   type = string
 }

--- a/compute.tf
+++ b/compute.tf
@@ -49,7 +49,7 @@ resource "google_compute_instance" "container_host" {
   }
 
   metadata = {
-    ssh-keys  = "${var.user}:${file(var.public_key_path)}"
+    ssh-keys  = "${var.user}:${fileexists(var.public_key_path) ? file(var.public_key_path) : var.public_key}"
     user-data = local.cloud_config
   }
 

--- a/locals.tf
+++ b/locals.tf
@@ -47,7 +47,7 @@ locals {
                 EOT3
     },
     {
-      path        = "/mnt/disks/data/caddy/Caddyfile"
+      path        = "/tmp/Caddyfile"
       permissions = "0644"
       owner       = "root"
       content     = <<-EOT4
@@ -64,8 +64,14 @@ locals {
       content     = <<-EOT5
         #!/bin/bash
       
-        mkfs.ext4 -L data -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard /dev/sdb
+        mkfs.ext4 -L data -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard /dev/disk/by-id/google-persistent-disk-1
         mkdir -p /mnt/disks/data
+        mount -t ext4 -o nodev,nosuid /dev/disk/by-id/google-persistent-disk-1 /mnt/disks/data
+        mkdir -p /mnt/disks/data/caddy
+        mkdir -p /mnt/disks/data/caddy/data
+        mkdir -p /mnt/disks/data/caddy/config
+        mkdir -p /mnt/disks/data/actual-data
+        cp /tmp/Caddyfile /mnt/disks/data/caddy/Caddyfile
         EOT5
     }
   ]
@@ -79,9 +85,9 @@ locals {
   ]
 
   bootcmd = [
-    "fsck.ext4 -tvy /dev/sdb",
+    "fsck.ext4 -tvy /dev/disk/by-id/google-persistent-disk-1",
     "mkdir -p /mnt/disks/data",
-    "mount -t ext4 -o nodev,nosuid /dev/sdb /mnt/disks/data",
+    "mount -t ext4 -o nodev,nosuid /dev/disk/by-id/google-persistent-disk-1 /mnt/disks/data",
     "mkdir -p /mnt/disks/data/caddy",
     "mkdir -p /mnt/disks/data/caddy/data",
     "mkdir -p /mnt/disks/data/caddy/config",


### PR DESCRIPTION
* Adds `public_key` variable, which is useful if executing Terraform from HCP Terraform instead of locally.
* Updates ssh-key configuration on the Compute Engine instance to account for the possibility of setting the SSH key via the `public_key` variable.
* Updates the cloud-init cloud config to attempt to address #10 - reliability issues with initializing and mounting the persistent data disk.